### PR TITLE
Added groups to RunnerDetails

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -72,6 +72,11 @@ type RunnerDetails struct {
 	Version        string   `json:"version"`
 	AccessLevel    string   `json:"access_level"`
 	MaximumTimeout int      `json:"maximum_timeout"`
+	Groups         []struct {
+		ID     int    `json:"id"`
+		Name   string `json:"name"`
+		WebURL string `json:"web_url"`
+	} `json:"groups"`
 }
 
 // ListRunnersOptions represents the available ListRunners() options.


### PR DESCRIPTION
Runners that are assigned to a group will provide the information as a groups list inside the runner details.
Sadly this is currently not documented (or I have not found it).

But here the response from the API:
![image](https://user-images.githubusercontent.com/9787279/65877061-037d1880-e38b-11e9-97a3-f94552eef4d1.png)
